### PR TITLE
DEV-1982 Move to event based snpchecking and support single sample

### DIFF
--- a/k8/hmf-pipeline-development/deploy.yaml
+++ b/k8/hmf-pipeline-development/deploy.yaml
@@ -1,51 +1,48 @@
-apiVersion: batch/v1beta1
-kind: CronJob
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: snpcheck
   namespace: acceptance
 spec:
-  concurrencyPolicy: Forbid
-  failedJobsHistoryLimit: 1
-  jobTemplate:
+  selector:
+    matchLabels:
+      app: snpcheck
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: snpcheck
+        tier: app
     spec:
-      completions: 1
-      parallelism: 1
-      template:
-        spec:
-          containers:
-            - args:
-                - --api_url
-                - http://hmfapi-gcp:5002
-                - --snpcheck_bucket
-                - hmf-snpcheck-development
-                - --snpcheck_private_key
-                - /snpcheck_secrets/bootstrap-key.json
-                - --database_private_key
-                - /database_secrets/bootstrap-key.json
-                - --project
-                - hmf-pipeline-development
-              command:
-                - /snpcheck.sh
-              image: eu.gcr.io/hmf-build/snpcheck
-              imagePullPolicy: Always
-              name: snpcheck
-              volumeMounts:
-                - mountPath: /snpcheck_secrets/
-                  name: snpcheck-secrets
-                - mountPath: /database_secrets/
-                  name: database-secrets
-          dnsPolicy: ClusterFirst
-          restartPolicy: Never
-          schedulerName: default-scheduler
-          volumes:
-            - name: snpcheck-secrets
-              secret:
-                defaultMode: 420
-                secretName: gcp-pipeline5-scheduler
-            - name: database-secrets
-              secret:
-                defaultMode: 420
-                secretName: gcp-pipeline5-scheduler
-  schedule: '*/30 * * * *'
-  successfulJobsHistoryLimit: 1
-  suspend: false
+      volumes:
+        - name: snpcheck-secrets
+          secret:
+            defaultMode: 420
+            secretName: gcp-pipeline5-scheduler
+        - name: database-secrets
+          secret:
+            defaultMode: 420
+            secretName: gcp-pipeline5-scheduler
+
+      containers:
+        - args:
+            - --api_url
+            - http://hmfapi-gcp:5002
+            - --snpcheck_bucket
+            - hmf-snpcheck-development
+            - --snpcheck_private_key
+            - /snpcheck_secrets/bootstrap-key.json
+            - --database_private_key
+            - /database_secrets/bootstrap-key.json
+            - --project
+            - hmf-pipeline-development
+          command:
+            - /snpcheck.sh
+          image: eu.gcr.io/hmf-build/snpcheck
+          imagePullPolicy: Always
+          name: snpcheck
+          volumeMounts:
+            - mountPath: /snpcheck_secrets/
+              name: snpcheck-secrets
+            - mountPath: /database_secrets/
+              name: database-secrets

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,9 @@
         <picocli.version>4.2.0</picocli.version>
         <slf4j-log4j12.version>1.7.28</slf4j-log4j12.version>
         <google-cloud-bom.version>0.145.0</google-cloud-bom.version>
-        <hmf-api.version>1.1.2</hmf-api.version>
+        <java-client.version>1.1.26</java-client.version>
         <pipeline5.version>5.18.1943</pipeline5.version>
+        <pipeline-events.version>1.1.14</pipeline-events.version>
     </properties>
 
     <repositories>
@@ -38,7 +39,12 @@
         <dependency>
             <groupId>com.hartwig.api</groupId>
             <artifactId>java-client</artifactId>
-            <version>${hmf-api.version}</version>
+            <version>${java-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hartwig</groupId>
+            <artifactId>pipeline-events</artifactId>
+            <version>${pipeline-events.version}</version>
         </dependency>
         <dependency>
             <groupId>com.hartwig</groupId>


### PR DESCRIPTION
Will run a snpcheck for every staged pipeline with tertiary analysis and patient report target, when the
run is a somatic or single sample.