### PR TITLE
DEV-2143 Buffer runs without lab vcfs and try again

### DIFF
--- a/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
+++ b/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
@@ -1,0 +1,34 @@
+package com.hartwig.snpcheck;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import com.hartwig.events.PipelineStaged;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LabPendingBuffer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LabPendingBuffer.class);
+
+    private final SnpCheck snpCheck;
+    private final ScheduledExecutorService scheduler;
+    private final TimeUnit delayUnit;
+    private final int delay;
+
+    public LabPendingBuffer(final SnpCheck snpCheck, final ScheduledExecutorService scheduler, final TimeUnit delayUnit, final int delay) {
+        this.snpCheck = snpCheck;
+        this.scheduler = scheduler;
+        this.delayUnit = delayUnit;
+        this.delay = delay;
+    }
+
+    public void add(final PipelineStaged buffered) {
+        LOGGER.info("Scheduling sample [{}] to be reprocessed in 1 hour", buffered.sample());
+        scheduler.schedule(() -> {
+            LOGGER.info("Reprocessing sample [{}] as lab VCF was not available on last attempt", buffered.sample());
+            snpCheck.handle(buffered);
+        }, delay, delayUnit);
+    }
+}

--- a/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
@@ -10,7 +10,6 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.hartwig.api.HmfApi;
 import com.hartwig.events.EventSubscriber;
-import com.hartwig.events.PipelineEvent;
 import com.hartwig.events.PipelineStaged;
 
 import org.slf4j.Logger;

--- a/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
+++ b/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
@@ -1,0 +1,33 @@
+package com.hartwig.snpcheck;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import com.hartwig.events.Analysis;
+import com.hartwig.events.PipelineStaged;
+
+import org.junit.Test;
+
+public class LabPendingBufferTest {
+
+    @Test
+    public void schedulesAnotherRunAfterConfiguredDelay() throws Exception {
+        SnpCheck snpCheck = mock(SnpCheck.class);
+        LabPendingBuffer victim = new LabPendingBuffer(snpCheck, Executors.newSingleThreadScheduledExecutor(), TimeUnit.MILLISECONDS, 1);
+        PipelineStaged event = PipelineStaged.builder()
+                .sample("sample")
+                .analysisContext(Analysis.Context.DIAGNOSTIC)
+                .analysisMolecule(Analysis.Molecule.DNA)
+                .analysisType(Analysis.Type.TERTIARY)
+                .version("5.23")
+                .setId(1L)
+                .build();
+        victim.add(event);
+        Thread.sleep(500);
+        verify(snpCheck, times(1)).handle(event);
+    }
+}


### PR DESCRIPTION
Adding notification events to the bucket or from the upload script will be tricky without some additional
smarts built into the syncing process to parse out samples (rsync is used).

Instead we just schedule another try until we get the lab vcf.