### PR TITLE
DEV-2194: Handle R sample barcodes with underscore notation

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,34 @@
 steps:
-  - name: 'maven:3-jdk-11'
-    id: 'Building application'
-    entrypoint: mvn
-    args: ['install', '-B']
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args:
+      - '-m'
+      - 'rsync'
+      - '-r'
+      - 'gs://hmf-build-caches/snpcheck/.m2'
+      - '/cache/.m2'
+    volumes:
+      - path: '/cache/.m2'
+        name: 'm2_cache'
+
+  - name: 'gcr.io/cloud-builders/mvn'
+    args:
+      - 'install'
+      - '--batch-mode'
+    volumes:
+      - path: '/cache/.m2'
+        name: 'm2_cache'
+    env:
+      - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
+  - name: 'gcr.io/cloud-builders/gsutil'
+    args:
+      - '-m'
+      - 'rsync'
+      - '-r'
+      - '/cache/.m2'
+      - 'gs://hmf-build-caches/snpcheck/.m2/'
+    volumes:
+      - path: '/cache/.m2'
+        name: 'm2_cache'
   - name: 'gcr.io/cloud-builders/docker'
     id: 'Building image'
     args: ['build', '-t', 'eu.gcr.io/$PROJECT_ID/snpcheck:$SHORT_SHA', '.']

--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -82,7 +82,8 @@ public class SnpCheck {
     }
 
     private static Optional<Blob> findValidationVcf(final Iterable<Blob> valVcfs, final Sample refSample) {
-        return StreamSupport.stream(valVcfs.spliterator(), false).filter(vcf -> vcf.getName().contains(refSample.getBarcode())).findFirst();
+        String barcode = refSample.getBarcode().split("_")[0];
+        return StreamSupport.stream(valVcfs.spliterator(), false).filter(vcf -> vcf.getName().startsWith(barcode)).findFirst();
     }
 
     private void doComparison(final Run run, final Sample refSample, final Sample tumorSample, final Blob valVcf) {


### PR DESCRIPTION
Discussed testing the new R sample barcode option (which includes an underscore), but I think it only makes sense to add an actual test if there are "{barcode}_{sampleName}*_OpenArrayCalls.vcf" files to search for, and I see no reference to them anywhere else, not as file but also not in code.

Also:
- I changed contains() to startsWith() since the barcode has always been at the start.
- Does the findFirst() literally find the oldest VCF in bucket? Because it makes more sense to select the most recent I think, so perhaps findLast() is better?