### PR TITLE
DEV-2209 Push PipelineValidated message when done

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <google-cloud-bom.version>0.145.0</google-cloud-bom.version>
         <java-client.version>1.1.26</java-client.version>
         <pipeline5.version>5.18.1943</pipeline5.version>
-        <pipeline-events.version>local-SNAPSHOT</pipeline-events.version>
+        <pipeline-events.version>1.2.20</pipeline-events.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <google-cloud-bom.version>0.145.0</google-cloud-bom.version>
         <java-client.version>1.1.26</java-client.version>
         <pipeline5.version>5.18.1943</pipeline5.version>
-        <pipeline-events.version>1.2.13</pipeline-events.version>
+        <pipeline-events.version>local-SNAPSHOT</pipeline-events.version>
     </properties>
 
     <repositories>

--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -62,8 +62,7 @@ public class SnpCheck implements Handler<PipelineStaged> {
 
     public void handle(final PipelineStaged event) {
         try {
-            if (event.analysisType().equals(Type.TERTIARY) && (event.analysisContext().equals(Context.DIAGNOSTIC) || event.analysisContext()
-                    .equals(Context.SERVICES))) {
+            if (event.analysisType().equals(Type.TERTIARY) && !event.analysisContext().equals(Context.SHALLOW)) {
                 Run run = runs.get(event.runId().orElseThrow());
                 if (run.getIni().equals(Ini.SOMATIC_INI.getValue()) || run.getIni().equals(Ini.SINGLESAMPLE_INI.getValue())) {
                     LOGGER.info("Received a SnpCheck candidate [{}]", run.getSet().getName());
@@ -84,17 +83,7 @@ public class SnpCheck implements Handler<PipelineStaged> {
                                         .result(result.name().toLowerCase())
                                         .build()
                                         .publish();
-                                PipelineValidated.builder()
-                                        .analysisContext(event.analysisContext())
-                                        .analysisType(event.analysisType())
-                                        .sample(event.sample())
-                                        .analysisMolecule(event.analysisMolecule())
-                                        .version(event.version())
-                                        .runId(event.runId())
-                                        .setId(event.setId())
-                                        .blobs(event.blobs())
-                                        .build().publish(publisher, objectMapper);
-
+                                PipelineValidated.builder().originalEvent(event).build().publish(publisher, objectMapper);
                             } else {
                                 LOGGER.info("No validation VCF available for set [{}].", run.getSet().getName());
                                 labPendingBuffer.add(event);


### PR DESCRIPTION
This will allow us to eliminate a race condition that occurs when the lab
doesn't immediately process the snpcheck for a run, and the run completes
pipeline processing before snpcheck results are available. This is not an
exceptional case, it happens relatively frequently.