### PR TITLE
DEV-2759 Re-queue buffered events on failure

### DIFF
--- a/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
+++ b/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
@@ -31,7 +31,7 @@ public class LabPendingBuffer {
                 LOGGER.info("Reprocessing sample [{}] as lab VCF was not available on last attempt", buffered.pipeline().sample());
                 snpCheck.handle(buffered);
             } catch (Exception e) {
-                LOGGER.warn("Failed to reprocess sample", e);
+                LOGGER.warn("Failed to reprocess sample [{}]; re-queueing", buffered.pipeline().sample(), e);
                 this.add(buffered);
             }
         }, delay, delayUnit);

--- a/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
+++ b/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
@@ -27,8 +27,13 @@ public class LabPendingBuffer {
     public void add(final PipelineComplete buffered) {
         LOGGER.info("Scheduling sample [{}] to be reprocessed in 1 hour", buffered.pipeline().sample());
         scheduler.schedule(() -> {
-            LOGGER.info("Reprocessing sample [{}] as lab VCF was not available on last attempt", buffered.pipeline().sample());
-            snpCheck.handle(buffered);
+            try {
+                LOGGER.info("Reprocessing sample [{}] as lab VCF was not available on last attempt", buffered.pipeline().sample());
+                snpCheck.handle(buffered);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to reprocess sample", e);
+                this.add(buffered);
+            }
         }, delay, delayUnit);
     }
 }

--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -106,7 +106,7 @@ public class SnpCheck implements Handler<PipelineComplete> {
                 publishValidated(event);
             }
         } catch (Exception e) {
-            LOGGER.error("SnpCheck failed", e);
+            throw new RuntimeException("Failed to process SnpCheck");
         }
     }
 


### PR DESCRIPTION
Prior to this change any exception when a buffered event was reprocessed would
essentially be swallowed as the handler would log the error only and the caller
would have no way to know something had happened.

Instead we now re-throw any exception as an unchecked exception and re-buffer
the request in this situation.