### PR TITLE
DEV-2813 Passthru flag

### DIFF
--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -25,7 +25,6 @@ import com.hartwig.api.model.SampleType;
 import com.hartwig.api.model.Status;
 import com.hartwig.api.model.UpdateRun;
 import com.hartwig.events.Handler;
-import com.hartwig.events.Pipeline;
 import com.hartwig.events.PipelineComplete;
 import com.hartwig.events.PipelineValidated;
 import com.hartwig.snpcheck.VcfComparison.Result;
@@ -49,10 +48,11 @@ public class SnpCheck implements Handler<PipelineComplete> {
     private final Publisher validatedTopicPublisher;
     private final ObjectMapper objectMapper;
     private final LabPendingBuffer labPendingBuffer;
+    private final boolean passthru;
 
     public SnpCheck(final RunApi runs, final SampleApi samples, final Bucket snpcheckBucket, final Storage pipelineStorage,
-            final VcfComparison vcfComparison, final Publisher publisher, final Publisher validatedTopicPublisher,
-            final ObjectMapper objectMapper) {
+                    final VcfComparison vcfComparison, final Publisher publisher, final Publisher validatedTopicPublisher,
+                    final ObjectMapper objectMapper, final boolean passthru) {
         this.runs = runs;
         this.samples = samples;
         this.snpcheckBucket = snpcheckBucket;
@@ -61,13 +61,17 @@ public class SnpCheck implements Handler<PipelineComplete> {
         this.turquoiseTopicPublisher = publisher;
         this.validatedTopicPublisher = validatedTopicPublisher;
         this.objectMapper = objectMapper;
+        this.passthru = passthru;
         this.labPendingBuffer = new LabPendingBuffer(this, Executors.newScheduledThreadPool(1), TimeUnit.HOURS, 1);
     }
 
     public void handle(final PipelineComplete event) {
         try {
             Run run = runs.get(event.pipeline().runId());
-            if (run.getIni().equals(Ini.SOMATIC_INI.getValue()) || run.getIni().equals(Ini.SINGLESAMPLE_INI.getValue())) {
+            if (passthru) {
+                LOGGER.info("Passing through rerun event for sample [{}]", event.pipeline().sample());
+                publishValidated(event);
+            } else if (run.getIni().equals(Ini.SOMATIC_INI.getValue()) || run.getIni().equals(Ini.SINGLESAMPLE_INI.getValue())) {
                 LOGGER.info("Received a SnpCheck candidate [{}] for run [{}]", run.getSet().getName(), run.getId());
                 if (run.getStatus() == Status.FINISHED || runFailedQc(run)) {
                     Iterable<Blob> valVcfs = Optional.ofNullable(snpcheckBucket.list(Storage.BlobListOption.prefix(SNPCHECK_VCFS)))
@@ -101,9 +105,6 @@ public class SnpCheck implements Handler<PipelineComplete> {
                 } else {
                     LOGGER.info("Skipping run with status [{}]", run.getStatus());
                 }
-            } else if (run.getIni().equals(Ini.RERUN_INI.getValue())) {
-                LOGGER.info("Passing through rerun event for sample [{}]", event.pipeline().sample());
-                publishValidated(event);
             }
         } catch (Exception e) {
             throw new RuntimeException("Failed to process SnpCheck");

--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -69,7 +69,7 @@ public class SnpCheck implements Handler<PipelineComplete> {
         try {
             Run run = runs.get(event.pipeline().runId());
             if (passthru) {
-                LOGGER.info("Passing through rerun event for sample [{}]", event.pipeline().sample());
+                LOGGER.info("Passing through event for sample [{}]", event.pipeline().sample());
                 publishValidated(event);
             } else if (run.getIni().equals(Ini.SOMATIC_INI.getValue()) || run.getIni().equals(Ini.SINGLESAMPLE_INI.getValue())) {
                 LOGGER.info("Received a SnpCheck candidate [{}] for run [{}]", run.getSet().getName(), run.getId());

--- a/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
@@ -47,7 +47,7 @@ public class SnpCheckMain implements Callable<Integer> {
                         description = "Project in which the snpcheck is running")
     private String project;
     @CommandLine.Option(names = { "--passthru" },
-            required = true,
+            defaultValue = "false",
             description = "Mark all events as validated without actually validating against the snpcheck vcf.")
     private boolean passthru;
 

--- a/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
@@ -46,6 +46,10 @@ public class SnpCheckMain implements Callable<Integer> {
                         required = true,
                         description = "Project in which the snpcheck is running")
     private String project;
+    @CommandLine.Option(names = { "--passthru" },
+            required = true,
+            description = "Mark all events as validated without actually validating against the snpcheck vcf.")
+    private boolean passthru;
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -83,7 +87,7 @@ public class SnpCheckMain implements Callable<Integer> {
                             Publisher.newBuilder(ProjectTopicName.of(project, PipelineValidated.TOPIC))
                                     .setCredentialsProvider(() -> snpCheckCredentials)
                                     .build(),
-                            OBJECT_MAPPER));
+                            OBJECT_MAPPER, passthru));
             return 0;
         } catch (Exception e) {
             LOGGER.error("Exception while running snpcheck", e);

--- a/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
+++ b/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
@@ -108,7 +108,7 @@ public class SnpCheckTest {
                 vcfComparison,
                 turquoiseTopicPublisher,
                 validatedTopicPublisher,
-                OBJECT_MAPPER);
+                OBJECT_MAPPER, false);
     }
 
     private Run run(final Ini somaticIni) {
@@ -260,7 +260,15 @@ public class SnpCheckTest {
     }
 
     @Test
-    public void passesThroughRerunIni() {
+    public void passesThruWhenFlagSet() {
+        victim = new SnpCheck(runApi,
+                sampleApi,
+                snpcheckBucket,
+                pipelineStorage,
+                vcfComparison,
+                turquoiseTopicPublisher,
+                validatedTopicPublisher,
+                OBJECT_MAPPER, true);
         when(runApi.get(run.getId())).thenReturn(run.ini(Ini.RERUN_INI.getValue()));
         victim.handle(stagedEvent(Context.RESEARCH));
         ArgumentCaptor<PubsubMessage> pubsubMessageArgumentCaptor = ArgumentCaptor.forClass(PubsubMessage.class);


### PR DESCRIPTION
Instead of passing through only reruns, allow to configure this behaviour at the deployment
level, so we can also use in prod when snpcheck machine unavailable.