### PR TITLE
DEV-2955 Remove storage.buckets.get requirement

### DIFF
--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -35,8 +35,8 @@ public class SnpCheck implements Handler<PipelineComplete> {
 
     private final RunApi runs;
     private final SampleApi samples;
-    private final Bucket snpcheckBucket;
     private final Storage pipelineStorage;
+    private final String bucketName;
     private final VcfComparison vcfComparison;
     private final Publisher turquoiseTopicPublisher;
     private final Publisher validatedTopicPublisher;
@@ -44,13 +44,13 @@ public class SnpCheck implements Handler<PipelineComplete> {
     private final LabPendingBuffer labPendingBuffer;
     private final boolean passthru;
 
-    public SnpCheck(final RunApi runs, final SampleApi samples, final Bucket snpcheckBucket, final Storage pipelineStorage,
+    public SnpCheck(final RunApi runs, final SampleApi samples, final Storage pipelineStorage, final String bucketName,
                     final VcfComparison vcfComparison, final Publisher publisher, final Publisher validatedTopicPublisher,
                     final ObjectMapper objectMapper, final boolean passthru) {
         this.runs = runs;
         this.samples = samples;
-        this.snpcheckBucket = snpcheckBucket;
         this.pipelineStorage = pipelineStorage;
+        this.bucketName = bucketName;
         this.vcfComparison = vcfComparison;
         this.turquoiseTopicPublisher = publisher;
         this.validatedTopicPublisher = validatedTopicPublisher;
@@ -76,7 +76,7 @@ public class SnpCheck implements Handler<PipelineComplete> {
 
     private void validateRunWithSnpcheck(final PipelineComplete event, final Run run) {
         if (run.getStatus() == Status.FINISHED || runFailedQc(run)) {
-            Iterable<Blob> valVcfs = Optional.ofNullable(snpcheckBucket.list(Storage.BlobListOption.prefix(SNPCHECK_VCFS)))
+            Iterable<Blob> valVcfs = Optional.ofNullable(pipelineStorage.list(bucketName, Storage.BlobListOption.prefix(SNPCHECK_VCFS)))
                     .map(Page::iterateAll)
                     .orElse(Collections.emptyList());
             Optional<Sample> maybeRefSample = onlyOne(samples, run.getSet(), SampleType.REF);

--- a/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
@@ -56,12 +56,6 @@ public class SnpCheckMain implements Callable<Integer> {
     public Integer call() {
         try {
             HmfApi hmfApi = HmfApi.create(apiUrl);
-            Bucket snpcheckBucket = StorageOptions.getDefaultInstance().getService().get(snpcheckBucketName);
-            if (snpcheckBucket == null) {
-                LOGGER.error("Bucket [{}] does not exist. ", snpcheckBucketName);
-                return 1;
-            }
-
             if (passthru && project.contains("prod")){
                 LOGGER.error("Snpcheck does not allow configuring passthru on a production project.");
                 return 1;
@@ -72,8 +66,8 @@ public class SnpCheckMain implements Callable<Integer> {
                     PipelineComplete.class)
                     .subscribe(new SnpCheck(hmfApi.runs(),
                             hmfApi.samples(),
-                            snpcheckBucket,
                             StorageOptions.getDefaultInstance().getService(),
+                            snpcheckBucketName,
                             new PerlVcfComparison(),
                             Publisher.newBuilder(ProjectTopicName.of(project, "turquoise.events")).build(),
                             Publisher.newBuilder(ProjectTopicName.of(project, PipelineValidated.TOPIC)).build(),

--- a/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
+++ b/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
@@ -47,7 +47,7 @@ public class SnpCheckTest {
     private RunApi runApi;
     private SampleApi sampleApi;
     private Storage pipelineStorage;
-    private Bucket snpcheckBucket;
+    private String snpcheckBucket;
     private VcfComparison vcfComparison;
     private Publisher turquoiseTopicPublisher;
     private Publisher validatedTopicPublisher;
@@ -69,7 +69,7 @@ public class SnpCheckTest {
         runApi = mock(RunApi.class);
         sampleApi = mock(SampleApi.class);
         pipelineStorage = mock(Storage.class);
-        snpcheckBucket = mock(Bucket.class);
+        snpcheckBucket = "bucket";
         vcfComparison = mock(VcfComparison.class);
         turquoiseTopicPublisher = mock(Publisher.class);
         validatedTopicPublisher = mock(Publisher.class);
@@ -86,8 +86,8 @@ public class SnpCheckTest {
                 .build();
         victim = new SnpCheck(runApi,
                 sampleApi,
-                snpcheckBucket,
                 pipelineStorage,
+                snpcheckBucket,
                 vcfComparison,
                 turquoiseTopicPublisher,
                 validatedTopicPublisher,
@@ -164,7 +164,7 @@ public class SnpCheckTest {
         Blob validationVcf = mock(Blob.class);
         when(validationVcf.getName()).thenReturn(BARCODE + ".vcf");
         when(page.iterateAll()).thenReturn(singletonList(validationVcf));
-        when(snpcheckBucket.list(Storage.BlobListOption.prefix(SnpCheck.SNPCHECK_VCFS))).thenReturn(page);
+        when(pipelineStorage.list(snpcheckBucket, Storage.BlobListOption.prefix(SnpCheck.SNPCHECK_VCFS))).thenReturn(page);
         victim.handle(stagedEvent(Context.DIAGNOSTIC));
         assertTechnicalFailure();
     }
@@ -283,8 +283,8 @@ public class SnpCheckTest {
     public void passesThruWhenFlagSet() {
         victim = new SnpCheck(runApi,
                 sampleApi,
-                snpcheckBucket,
                 pipelineStorage,
+                snpcheckBucket,
                 vcfComparison,
                 turquoiseTopicPublisher,
                 validatedTopicPublisher,
@@ -388,7 +388,7 @@ public class SnpCheckTest {
         Blob validationVcf = mock(Blob.class);
         when(validationVcf.getName()).thenReturn("/path/" + barcode + ".vcf");
         when(page.iterateAll()).thenReturn(singletonList(validationVcf));
-        when(snpcheckBucket.list(Storage.BlobListOption.prefix(SnpCheck.SNPCHECK_VCFS))).thenReturn(page);
+        when(pipelineStorage.list(snpcheckBucket, Storage.BlobListOption.prefix(SnpCheck.SNPCHECK_VCFS))).thenReturn(page);
         Bucket referenceBucket = mock(Bucket.class);
         when(pipelineStorage.get(this.run.getBucket())).thenReturn(referenceBucket);
         Blob referenceVcf = mock(Blob.class);


### PR DESCRIPTION
Rather than fetch the storage bucket up-front, make it so we only try to open the bucket when we're actually reading from it.

Also change the storage interactions so we never try to "get" the bucket, hence eliminating the need for the storage.buckets.get role.