### PR TITLE
DEV-3013 Port to new events, CLI option mixins and shared parent pom

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.1.0</version>
+    </extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,147 +4,62 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.hartwig.cloud-sdk</groupId>
+        <artifactId>cloud-sdk</artifactId>
+        <version>local-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
     <groupId>com.hartwig</groupId>
     <artifactId>snpcheck</artifactId>
     <version>local-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
-        <junit.version>4.12</junit.version>
-        <immutables.version>2.5.5</immutables.version>
-        <mockito.version>2.23.4</mockito.version>
-        <assertj-core.version>3.8.0</assertj-core.version>
-        <slf4j-api.version>1.7.25</slf4j-api.version>
-        <picocli.version>4.2.0</picocli.version>
-        <slf4j-log4j12.version>1.7.28</slf4j-log4j12.version>
-        <google-cloud-bom.version>0.145.0</google-cloud-bom.version>
-        <java-client.version>1.26.0</java-client.version>
-        <pipeline5.version>5.18.1943</pipeline5.version>
-        <pipeline-events.version>3.0.0</pipeline-events.version>
-    </properties>
-
     <repositories>
         <repository>
-            <id>hmf-maven-repository-release</id>
-            <url>gs://hmf-maven-repository/release</url>
+            <id>artifact-registry</id>
+            <url>gs://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
+
+    <properties>
+        <main.class>com.hartwig.snpcheck.SnpCheckMain</main.class>
+    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.hartwig.api</groupId>
             <artifactId>java-client</artifactId>
-            <version>${java-client.version}</version>
+            <version>1.30.1</version>
         </dependency>
         <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>pipeline-events</artifactId>
-            <version>${pipeline-events.version}</version>
+            <groupId>com.hartwig.events</groupId>
+            <artifactId>events-pipeline</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.hartwig</groupId>
-            <artifactId>cluster</artifactId>
-            <version>${pipeline5.version}</version>
+            <groupId>com.hartwig.events</groupId>
+            <artifactId>events-pubsub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hartwig.cloud-sdk</groupId>
+            <artifactId>cli</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
-            <version>${immutables.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>${picocli.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j-log4j12.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
-
-    <build>
-        <extensions>
-            <extension>
-                <groupId>com.gkatzioura.maven.cloud</groupId>
-                <artifactId>google-storage-wagon</artifactId>
-                <version>1.0</version>
-            </extension>
-        </extensions>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <useUniqueVersions>false</useUniqueVersions>
-                            <addClasspath>true</addClasspath>
-                            <mainClass>com.hartwig.snpcheck.SnpCheckMain</mainClass>
-                            <classpathPrefix>lib/</classpathPrefix>
-                            <addDefaultImplementationEntries>
-                                true
-                            </addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.2</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hartwig.cloud-sdk</groupId>
         <artifactId>cloud-sdk</artifactId>
-        <version>local-SNAPSHOT</version>
+        <version>2.5.0</version>
         <relativePath/>
     </parent>
     <groupId>com.hartwig</groupId>
@@ -18,7 +18,7 @@
     <repositories>
         <repository>
             <id>artifact-registry</id>
-            <url>gs://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
+            <url>artifactregistry://europe-west4-maven.pkg.dev/hmf-build/hmf-maven</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -62,4 +62,5 @@
         </dependency>
 
     </dependencies>
+
 </project>

--- a/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
+++ b/src/main/java/com/hartwig/snpcheck/LabPendingBuffer.java
@@ -3,7 +3,7 @@ package com.hartwig.snpcheck;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import com.hartwig.events.PipelineComplete;
+import com.hartwig.events.pipeline.PipelineComplete;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheckMain.java
@@ -1,82 +1,74 @@
 package com.hartwig.snpcheck;
 
-import java.util.concurrent.Callable;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.storage.StorageOptions;
-import com.google.pubsub.v1.ProjectTopicName;
-import com.hartwig.api.HmfApi;
-import com.hartwig.events.EventSubscriber;
-import com.hartwig.events.PipelineComplete;
-import com.hartwig.events.PipelineValidated;
-
+import com.hartwig.cli.options.ApiOptions;
+import com.hartwig.cli.options.PubsubOptions;
+import com.hartwig.cli.options.TurquoiseOptions;
+import com.hartwig.events.pipeline.PipelineComplete;
+import com.hartwig.events.pipeline.PipelineValidated;
+import com.hartwig.events.pubsub.EventPublisher;
+import com.hartwig.events.pubsub.EventSubscriber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
 
 public class SnpCheckMain implements Callable<Integer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SnpCheckMain.class);
 
-    @CommandLine.Option(names = { "--api_url" },
-                        required = true,
-                        description = "URL from which to connect to the API")
-    private String apiUrl;
+    @CommandLine.Mixin
+    private final ApiOptions apiOptions = new ApiOptions();
 
-    @CommandLine.Option(names = { "--snpcheck_bucket" },
-                        defaultValue = "hmf-snpcheck",
-                        description = "Bucket in which the snpcheck vcfs are uploaded")
+    @CommandLine.Mixin
+    private final PubsubOptions pubsubOptions = new PubsubOptions();
+
+    @CommandLine.Mixin
+    private final TurquoiseOptions turquoiseOptions = new TurquoiseOptions();
+
+    @CommandLine.Option(names = {"--snpcheck_bucket"},
+            defaultValue = "hmf-snpcheck",
+            description = "Bucket in which the snpcheck vcfs are uploaded")
     private String snpcheckBucketName;
 
-    @CommandLine.Option(names = { "--project" },
-                        required = true,
-                        description = "Project in which the snpcheck is running")
+    @CommandLine.Option(names = {"--project"},
+            required = true,
+            description = "Project in which the snpcheck is running")
     private String project;
 
-    @CommandLine.Option(names = { "--passthru" },
+    @CommandLine.Option(names = {"--passthru"},
             defaultValue = "false",
             description = "Mark all events as validated without actually validating against the snpcheck vcf.")
     private boolean passthru;
 
-    @CommandLine.Option(names = { "--always_pass" },
-                        defaultValue = "false",
-                        description = "Run the snpcheck script in always pass mode.")
+    @CommandLine.Option(names = {"--always_pass"},
+            defaultValue = "false",
+            description = "Run the snpcheck script in always pass mode.")
     private boolean alwaysPass;
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    static {
-        OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        OBJECT_MAPPER.registerModule(new JavaTimeModule());
-        OBJECT_MAPPER.registerModule(new Jdk8Module());
-    }
 
     @Override
     public Integer call() {
         try {
-            HmfApi hmfApi = HmfApi.create(apiUrl);
-            if (passthru && project.contains("prod")){
+            if (passthru && project.contains("prod")) {
                 LOGGER.error("Snpcheck does not allow configuring passthru on a production project.");
                 return 1;
             }
             LOGGER.info("Snpcheck configured to alwaysPass={} mode.", alwaysPass);
-
-            EventSubscriber.create(project,
-                    PipelineComplete.subscription(project, "snpcheck"),
-                    PipelineComplete.class)
-                    .subscribe(new SnpCheck(hmfApi.runs(),
-                            hmfApi.samples(),
-                            StorageOptions.getDefaultInstance().getService(),
-                            snpcheckBucketName,
-                            new PerlVcfComparison(),
-                            Publisher.newBuilder(ProjectTopicName.of(project, "turquoise.events")).build(),
-                            Publisher.newBuilder(ProjectTopicName.of(project, PipelineValidated.TOPIC)).build(),
-                            OBJECT_MAPPER, passthru, alwaysPass));
+            EventSubscriber<PipelineComplete> subscriber = pubsubOptions.eventSubscriber(new PipelineComplete.EventDescriptor(), "snpcheck");
+            EventPublisher<PipelineValidated> publisher = pubsubOptions.eventPublisher(new PipelineValidated.EventDescriptor());
+            subscriber.subscribe(new SnpCheck(apiOptions.api().runs(),
+                    apiOptions.api().samples(),
+                    StorageOptions.getDefaultInstance().getService(),
+                    snpcheckBucketName,
+                    new PerlVcfComparison(),
+                    turquoiseOptions.publisher(),
+                    publisher,
+                    passthru, alwaysPass));
             return 0;
         } catch (Exception e) {
             LOGGER.error("Exception while running snpcheck", e);

--- a/src/main/java/com/hartwig/snpcheck/turquoise/Event.java
+++ b/src/main/java/com/hartwig/snpcheck/turquoise/Event.java
@@ -1,0 +1,28 @@
+package com.hartwig.snpcheck.turquoise;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableEvent.class)
+public interface Event {
+
+    @Value.Parameter
+    ZonedDateTime timestamp();
+
+    @Value.Parameter
+    String type();
+
+    @Value.Parameter
+    List<Subject> subjects();
+
+    @Value.Parameter
+    List<Label> labels();
+
+    static Event of(final ZonedDateTime timestamp, final String eventType, final List<Subject> subject, final List<Label> labels) {
+        return ImmutableEvent.of(timestamp, eventType, subject, labels);
+    }
+}

--- a/src/main/java/com/hartwig/snpcheck/turquoise/Label.java
+++ b/src/main/java/com/hartwig/snpcheck/turquoise/Label.java
@@ -1,0 +1,19 @@
+package com.hartwig.snpcheck.turquoise;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableLabel.class)
+public interface Label {
+
+    @Value.Parameter
+    String name();
+
+    @Value.Parameter
+    String value();
+
+    static Label of(final String name, final String value) {
+        return ImmutableLabel.of(name, value);
+    }
+}

--- a/src/main/java/com/hartwig/snpcheck/turquoise/SnpCheckEvent.java
+++ b/src/main/java/com/hartwig/snpcheck/turquoise/SnpCheckEvent.java
@@ -4,9 +4,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.hartwig.pipeline.turquoise.Label;
-import com.hartwig.pipeline.turquoise.Subject;
-import com.hartwig.pipeline.turquoise.TurquoiseEvent;
 
 import org.immutables.value.Value;
 

--- a/src/main/java/com/hartwig/snpcheck/turquoise/Subject.java
+++ b/src/main/java/com/hartwig/snpcheck/turquoise/Subject.java
@@ -1,0 +1,24 @@
+package com.hartwig.snpcheck.turquoise;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableSubject.class)
+public interface Subject {
+
+    @Value.Parameter
+    String name();
+
+    @Value.Parameter
+    String type();
+
+    @Value.Parameter
+    List<Label> labels();
+
+    static Subject of(final String type, final String name, final List<Label> labels) {
+        return ImmutableSubject.of(name, type, labels);
+    }
+}

--- a/src/main/java/com/hartwig/snpcheck/turquoise/TurquoiseEvent.java
+++ b/src/main/java/com/hartwig/snpcheck/turquoise/TurquoiseEvent.java
@@ -1,0 +1,50 @@
+package com.hartwig.snpcheck.turquoise;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.api.core.ApiFuture;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.immutables.value.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public interface TurquoiseEvent {
+    Logger LOGGER = LoggerFactory.getLogger(TurquoiseEvent.class);
+
+    String eventType();
+
+    List<Subject> subjects();
+
+    List<Label> labels();
+
+    @Value.Default
+    default ZonedDateTime timestamp() {
+        return ZonedDateTime.now();
+    }
+
+    Publisher publisher();
+
+    default void publish() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.registerModule(new Jdk8Module());
+            LOGGER.info("Publishing message to Turquoise [{}]", this);
+            ApiFuture<String> future = publisher().publish(PubsubMessage.newBuilder()
+                    .setData(ByteString.copyFromUtf8(objectMapper.writeValueAsString(Event.of(timestamp(), eventType(), subjects(), labels()))))
+                    .build());
+            LOGGER.info("Message was published with id [{}]", future.get(10, TimeUnit.SECONDS));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
+++ b/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
@@ -7,9 +7,9 @@ import static org.mockito.Mockito.verify;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import com.hartwig.events.Analysis;
-import com.hartwig.events.Pipeline;
-import com.hartwig.events.PipelineComplete;
+import com.hartwig.events.pipeline.Analysis;
+import com.hartwig.events.pipeline.Pipeline;
+import com.hartwig.events.pipeline.PipelineComplete;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Uses the new event subscriber and publisher classes, and configures them with the new shared CLI module.

Also extends the new hmf-cloud-sdk parent pom which includes dependency management, common dependencies, a release profile for creating jars, and dist management.

Cuts the dependency between snpcheck and pipeline by copying some of the turquoise classes.