### PR TITLE
DEV-3252 Migrate to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.hartwig.cloud-sdk</groupId>
         <artifactId>cloud-sdk</artifactId>
-        <version>2.9.1</version>
+        <version>2.12.0</version>
         <relativePath/>
     </parent>
     <groupId>com.hartwig</groupId>
@@ -30,7 +30,7 @@
 
     <properties>
         <main.class>com.hartwig.snpcheck.SnpCheckMain</main.class>
-        <cloud-sdk.version>2.9.1</cloud-sdk.version>
+        <cloud-sdk.version>2.12.0</cloud-sdk.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
+++ b/src/test/java/com/hartwig/snpcheck/LabPendingBufferTest.java
@@ -10,8 +10,8 @@ import java.util.concurrent.TimeUnit;
 import com.hartwig.events.pipeline.Analysis;
 import com.hartwig.events.pipeline.Pipeline;
 import com.hartwig.events.pipeline.PipelineComplete;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
 
 public class LabPendingBufferTest {
 

--- a/src/test/java/com/hartwig/snpcheck/PerlVcfComparisonExecutionTest.java
+++ b/src/test/java/com/hartwig/snpcheck/PerlVcfComparisonExecutionTest.java
@@ -2,8 +2,8 @@ package com.hartwig.snpcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
 import com.hartwig.snpcheck.VcfComparison.Result;
+import org.junit.jupiter.api.Test;
 
 public class PerlVcfComparisonExecutionTest {
     private static final String USER_DIR = System.getProperty("user.dir");

--- a/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
+++ b/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
@@ -22,8 +22,8 @@ import com.hartwig.events.pipeline.Analysis.Type;
 import com.hartwig.events.pipeline.Pipeline.Context;
 import com.hartwig.events.pubsub.EventPublisher;
 import com.hartwig.snpcheck.VcfComparison.Result;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
@@ -33,6 +33,7 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -64,7 +65,7 @@ public class SnpCheckTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Before
+    @BeforeEach
     public void setUp() {
         run = run(Ini.SOMATIC_INI);
         runApi = mock(RunApi.class);
@@ -263,12 +264,14 @@ public class SnpCheckTest {
         assertValidatedInApi();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void illegalStateOnResearchRunsWithoutDiagnosticRun() {
         when(runApi.get(run.getId())).thenReturn(run);
         when(runApi.list(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null))
                 .thenReturn(Collections.emptyList());
-        victim.handle(stagedEvent(Context.RESEARCH));
+        assertThrows(IllegalStateException.class, () -> {
+            victim.handle(stagedEvent(Context.RESEARCH));
+        });
     }
 
     @Test


### PR DESCRIPTION
Migrated from JUnit 4 to JUnit 5.

Note: Tests PerlVcfComparisonExecutionTest.badSnpcheckAlwaysPassYieldsPass and PerlVcfComparisonExecutionTest.goodSnpcheckYieldsPass are failing locally due to an external Perl dependency not being installed on my machine, they should pass during cloud build.