### PR TITLE
DEV-3292 update release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:stable
+FROM maven:3.9.1-eclipse-temurin-11-focal
 
 RUN apt-get update && \
-    apt-get install -y libarray-diff-perl gnupg openjdk-11-jre
+    apt-get install -y libarray-diff-perl gnupg
 
 ADD snpcheck_compare_vcfs snpcheck_compare_vcfs
 RUN chmod a+x snpcheck_compare_vcfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@ FROM debian:stable
 RUN apt-get update && \
     apt-get install -y libarray-diff-perl gnupg openjdk-11-jre
 
-ADD bin/snpcheck.sh snpcheck.sh
 ADD snpcheck_compare_vcfs snpcheck_compare_vcfs
-RUN chmod a+x snpcheck.sh
 RUN chmod a+x snpcheck_compare_vcfs
 ADD target/lib /usr/share/hartwig/lib
 ADD target/snpcheck-local-SNAPSHOT.jar /usr/share/hartwig/snpcheck.jar
 
-ENTRYPOINT ["./snpcheck.sh"]
+CMD ["java", "-jar", "/usr/share/hartwig/snpcheck.jar"]

--- a/bin/snpcheck.sh
+++ b/bin/snpcheck.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-/usr/bin/java ${JAVA_OPTS} -jar /usr/share/hartwig/snpcheck.jar "$@"
-status=$?
-if [ ${status} -ne 0 ]; then
-  echo "Failed to start snpcheck: $status"
-  exit ${status}
-fi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,6 @@
 steps:
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - id: 'Populate Maven cache from bucket'
+    name: 'gcr.io/cloud-builders/gsutil'
     args:
       - '-m'
       - 'rsync'
@@ -10,7 +11,8 @@ steps:
       - path: '/cache/.m2'
         name: 'm2_cache'
 
-  - name: 'eu.gcr.io/hmf-build/maven:3.6.0-jdk-11-slim-libarray-diff-perl'
+  - id: 'Build application'
+    name: 'eu.gcr.io/hmf-build/maven:3.6.0-jdk-11-slim-libarray-diff-perl'
     entrypoint: 'mvn'
     args:
       - 'install'
@@ -22,7 +24,8 @@ steps:
         name: 'm2_cache'
     env:
       - MAVEN_OPTS=-Dmaven.repo.local=/cache/.m2
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - id: 'Save Maven cache'
+    name: 'gcr.io/cloud-builders/gsutil'
     args:
       - '-m'
       - 'rsync'
@@ -32,14 +35,10 @@ steps:
     volumes:
       - path: '/cache/.m2'
         name: 'm2_cache'
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Building image'
-    args: ['build', '-t', 'eu.gcr.io/$PROJECT_ID/snpcheck:$SHORT_SHA', '.']
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'Push image'
-    entrypoint: '/bin/bash'
-    args: ['-c', "docker push eu.gcr.io/$PROJECT_ID/snpcheck:$SHORT_SHA"]
+  - id: 'Publish docker image'
+    name: 'eu.gcr.io/hmf-build/docker-tag'
+    args: ['eu.gcr.io/hmf-build/snpcheck', '$TAG_NAME']
 options:
-  machineType: 'N1_HIGHCPU_32'
+  machineType: 'E2_HIGHCPU_8'
 images:
-  - eu.gcr.io/$PROJECT_ID/snpcheck
+  - eu.gcr.io/hmf-build/snpcheck


### PR DESCRIPTION
- `cloudbuild.yaml` now contains an `id` field for each step.
- `cloudbuild.yaml` now uses `hmf-build/docker-tag` to publish the docker image.
- remove unneeded shell script