### PR TITLE
DEV-3320 change CMD to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN chmod a+x snpcheck_compare_vcfs
 ADD target/lib /usr/share/hartwig/lib
 ADD target/snpcheck-local-SNAPSHOT.jar /usr/share/hartwig/snpcheck.jar
 
-CMD ["java", "-jar", "/usr/share/hartwig/snpcheck.jar"]
+ENTRYPOINT ["java", "-jar", "/usr/share/hartwig/snpcheck.jar"]


### PR DESCRIPTION
Change CMD to ENTRYPOINT because CMD caused the entrypoint to be overwriten when deployed to k8s which resulted in errors.