### PR TITLE
DEV-3618 Support reporting id for diagnostic context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,20 @@
     <properties>
         <main.class>com.hartwig.snpcheck.SnpCheckMain</main.class>
         <cloud-sdk.version>2.12.0</cloud-sdk.version>
+        <jackson-core.version>2.14.2</jackson-core.version>
+        <hmf-api-java-client.version>3.2.4</hmf-api-java-client.version>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson-core.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.hartwig.api</groupId>
             <artifactId>java-client</artifactId>
-            <version>1.30.1</version>
+            <version>${hmf-api-java-client.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
+++ b/src/test/java/com/hartwig/snpcheck/SnpCheckTest.java
@@ -144,7 +144,7 @@ public class SnpCheckTest {
     @Test
     public void finishedSomaticRunNoRefSampleMarksRunTechnicalFail() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(emptyList());
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(emptyList());
         victim.handle(stagedEvent(Context.DIAGNOSTIC));
         assertTechnicalFailure();
     }
@@ -152,15 +152,15 @@ public class SnpCheckTest {
     @Test
     public void finishedSomaticRunNoValidationVcfDoesNothing() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
         handleAndVerifyNoApiOrEventUpdates(stagedEvent(Context.DIAGNOSTIC));
     }
 
     @Test
     public void finishedSomaticRunNoRefVcfMarksRunTechnicalFail() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
         Page<Blob> page = mockPage();
         Blob validationVcf = mock(Blob.class);
         when(validationVcf.getName()).thenReturn(BARCODE + ".vcf");
@@ -207,7 +207,7 @@ public class SnpCheckTest {
     public void finishedSingleSampleRunComparedToValidationVcfPass() {
         Run singleSampleRun = run(Ini.SINGLESAMPLE_INI);
         when(runApi.get(run.getId())).thenReturn(singleSampleRun);
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
         setupValidationVcfs(VcfComparison.Result.PASS, singleSampleRun, BARCODE);
         victim.handle(stagedEvent(Context.DIAGNOSTIC));
         UpdateRun update = captureUpdate();
@@ -241,7 +241,7 @@ public class SnpCheckTest {
     @Test
     public void validatesResearchRunsWithDiagnosticSnpcheck() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(runApi.list(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null))
+        when(runApi.callList(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null, null))
                 .thenReturn(List.of(new Run().status(Status.VALIDATED).context("RESEARCH"), new Run().status(Status.VALIDATED).context("DIAGNOSTIC")));
         victim.handle(stagedEvent(Context.RESEARCH));
         ArgumentCaptor<PipelineValidated> pipelineValidatedArgumentCaptor = ArgumentCaptor.forClass(PipelineValidated.class);
@@ -254,7 +254,7 @@ public class SnpCheckTest {
     @Test
     public void validatesResearchRunsWithServicesSnpcheck() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(runApi.list(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null))
+        when(runApi.callList(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null, null))
                 .thenReturn(List.of(new Run().status(Status.VALIDATED).context("RESEARCH"), new Run().status(Status.VALIDATED).context("SERVICES")));
         victim.handle(stagedEvent(Context.RESEARCH));
         ArgumentCaptor<PipelineValidated> pipelineValidatedArgumentCaptor = ArgumentCaptor.forClass(PipelineValidated.class);
@@ -267,7 +267,7 @@ public class SnpCheckTest {
     @Test
     public void illegalStateOnResearchRunsWithoutDiagnosticRun() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(runApi.list(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null))
+        when(runApi.callList(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null, null))
                 .thenReturn(Collections.emptyList());
         assertThrows(IllegalStateException.class, () -> {
             victim.handle(stagedEvent(Context.RESEARCH));
@@ -277,7 +277,7 @@ public class SnpCheckTest {
     @Test
     public void errorOnResearchRunsWithNoDiagnosticRunSnpcheck() {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(runApi.list(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null))
+        when(runApi.callList(null, Ini.SOMATIC_INI, SET_ID, null, null, null, null, null, null))
                 .thenReturn(List.of(new Run().status(Status.VALIDATED).context("RESEARCH"),
                         new Run().context("DIAGNOSTIC").failure(new RunFailure().type(TypeEnum.QCFAILURE).source("SnpCheck"))));
         victim.handle(stagedEvent(Context.RESEARCH));
@@ -332,8 +332,8 @@ public class SnpCheckTest {
     }
 
     private void setupSnpcheckPassAndVerifyApiAndEventUpdates(PipelineComplete event) {
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
         setupValidationVcfs(Result.PASS, run, BARCODE);
         victim.handle(event);
         verify(vcfComparison).compare(any(), any(), any(), anyBoolean());
@@ -341,8 +341,8 @@ public class SnpCheckTest {
     }
 
     private void setupSnpcheckFailAndVerifyApiUpdateButNoEvents(PipelineComplete event) {
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
         setupValidationVcfs(Result.FAIL, run, BARCODE);
         victim.handle(event);
         verify(validatedTopicPublisher, never()).publish(any());
@@ -355,8 +355,8 @@ public class SnpCheckTest {
 
     private void setupHealthcheckAndVerifyNoApiUpdateButEvent(PipelineComplete event) {
         run = run.status(Status.FAILED).failure(new RunFailure().type(TypeEnum.QCFAILURE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
         setupValidationVcfs(Result.PASS, run, BARCODE);
         victim.handle(event);
         verify(runApi, never()).update(any(), any());
@@ -390,8 +390,8 @@ public class SnpCheckTest {
 
     private void fullSnpcheckWithResult(final VcfComparison.Result result, final String barcode) {
         when(runApi.get(run.getId())).thenReturn(run);
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
-        when(sampleApi.list(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.REF, null, null)).thenReturn(singletonList(REF_SAMPLE));
+        when(sampleApi.callList(null, null, null, SET_ID, SampleType.TUMOR, null, null)).thenReturn(singletonList(TUMOR_SAMPLE));
         setupValidationVcfs(result, run, barcode);
     }
 


### PR DESCRIPTION
Small change to find the correct path to snp genotype VCF in case of a diagnostic run (in new situation where we use the reporting id for running diagnostic pipelines).