### PR TITLE
INFRA-1330 Adjust api update logic

### DIFF
--- a/src/main/java/com/hartwig/snpcheck/SnpCheck.java
+++ b/src/main/java/com/hartwig/snpcheck/SnpCheck.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -172,7 +173,7 @@ public class SnpCheck implements EventHandler<PipelineComplete> {
             VcfComparison.Result result = vcfComparison.compare(run, refVcf, valVcf, alwaysPass);
             if (result.equals(VcfComparison.Result.PASS)) {
                 LOGGER.info("Set [{}] was successfully snpchecked.", run.getSet().getName());
-                if (!runFailedQc(run)) {
+                if (!runFailedQcHealthCheck(run)) {
                     apiValidated(run);
                 }
             } else {
@@ -194,6 +195,11 @@ public class SnpCheck implements EventHandler<PipelineComplete> {
     private static boolean runFailedQc(final Run run) {
         return run.getStatus() == Status.FAILED && (run.getFailure() != null && run.getFailure().getType() == TypeEnum.QCFAILURE);
     }
+
+    private static boolean runFailedQcHealthCheck(Run run) {
+        return runFailedQc(run) && Objects.requireNonNull(run.getFailure()).getSource().equals("HealthCheck");
+    }
+
 
     private Optional<Sample> findSample(RunSet set, SampleType type) {
         List<Sample> samples = sampleApi.callList(null, null, null, set.getId(), type, null, null);


### PR DESCRIPTION
Previously, if a run had a fail status with QC failure, then the API status would never be updated to validated even if a consecutive snpcheck passes.

However, this logic applied for both HealthCheck QC failure and SnpCheck QC failure. The latter does not make much sense. This is because this failure status means the snpcheck failed, but if we then do a new run and this succeeds, we would expect the api to be updated to validated.

This PR fixes this, and leaves the healthcheck logic in tact since there was an explicit test written for this case.